### PR TITLE
return an error when an extra field is sent to a resource

### DIFF
--- a/dsi/models/resources.go
+++ b/dsi/models/resources.go
@@ -30,8 +30,17 @@ func (obj *ResourceObject) Validate(definition *ResourceDefinition) error {
 	}
 
 	data := map[string]interface{}{}
+	missingKeys := []string{}
 	for key, val := range *obj {
-		data[key] = val
+		if _, ok := schema.Properties[key]; ok == false {
+			missingKeys = append(missingKeys, fmt.Sprintf("%s field is not defined in the schema", key))
+		} else {
+			data[key] = val
+		}
+	}
+
+	if len(missingKeys) > 0 {
+		return errors.New(strings.Join(missingKeys, ","))
 	}
 
 	// validate data against schema


### PR DESCRIPTION
Check to return an error when an extra field is sent to a resource. 
A resource can have just the defined fields