### PR TITLE
Implement relations

### DIFF
--- a/dsi/helpers.go
+++ b/dsi/helpers.go
@@ -37,7 +37,7 @@ var MaxLengthOfCollectionInfo = 12
 var ValidPathFormat = regexp.MustCompile(`^[a-zA-Z0-9_-]*$`)
 
 // reservedFieldKeys is the list of keys that cannot be used, as they are reserved for machinable use
-var reservedFieldKeys = []string{JSONIDKey, DocumentIDKey, LimitKey, OffsetKey, SortKey, MetadataKey, MetadataCreated, MetadataCreator, MetadataCreatorType}
+var reservedFieldKeys = []string{JSONIDKey, DocumentIDKey, LimitKey, OffsetKey, SortKey, MetadataKey, MetadataCreated, MetadataCreator, MetadataCreatorType, RelationKey}
 
 // ReservedField returns true if the string is a reserved field key
 func ReservedField(a string) bool {

--- a/dsi/helpers.go
+++ b/dsi/helpers.go
@@ -18,6 +18,8 @@ const (
 	OffsetKey = "_offset"
 	// SortKey is used for sorting the query by a field
 	SortKey = "_sort"
+	// RelationKey is used for relations
+	RelationKey = "_relation"
 	// MetadataKey is the key used to store internal metadata for an object
 	MetadataKey         = "_metadata"
 	MetadataCreated     = "_metadata.created"

--- a/dsi/interfaces/project_resources.go
+++ b/dsi/interfaces/project_resources.go
@@ -20,8 +20,8 @@ type ResourcesDatastore interface {
 	// Project definition documents
 	AddDefDocument(projectID, path string, fields models.ResourceObject, metadata *models.MetaData) (string, *errors.DatastoreError)
 	UpdateDefDocument(projectID, path, documentID string, updatedFields models.ResourceObject, filter map[string]interface{}) (*models.ResourceObject, *errors.DatastoreError)
-	ListDefDocuments(projectID, path string, limit, offset int64, filter map[string]interface{}, sort map[string]int) ([]map[string]interface{}, *errors.DatastoreError)
-	GetDefDocument(projectID, path, documentID string, filter map[string]interface{}) (map[string]interface{}, *errors.DatastoreError)
+	ListDefDocuments(projectID, path string, limit, offset int64, filter map[string]interface{}, sort map[string]int, relations map[string]string) ([]map[string]interface{}, *errors.DatastoreError)
+	GetDefDocument(projectID, path, documentID string, filter map[string]interface{}, relations map[string]string) (map[string]interface{}, *errors.DatastoreError)
 	CountDefDocuments(projectID, path string, filter map[string]interface{}) (int64, *errors.DatastoreError)
 	DeleteDefDocument(projectID, path, documentID string, filter map[string]interface{}) *errors.DatastoreError
 	DropDefDocuments(projectID, path string) *errors.DatastoreError

--- a/dsi/postgres/postgres.go
+++ b/dsi/postgres/postgres.go
@@ -30,7 +30,7 @@ func New(user, password, host, database string) (*Database, error) {
 	}, nil
 }
 
-func (d *Database) mapToQuery(filter map[string]interface{}, validFields map[string]bool, filterString *[]string, args *[]interface{}, index *int) error {
+func (d *Database) mapToQuery(filter map[string]interface{}, validFields map[string]bool, filterString *[]string, args *[]interface{}, index *int, tableAlias string) error {
 	for key, value := range filter {
 		if _, acceptsAny := validFields["*"]; !acceptsAny {
 			if _, ok := validFields[key]; !ok {
@@ -40,7 +40,12 @@ func (d *Database) mapToQuery(filter map[string]interface{}, validFields map[str
 		}
 
 		*args = append(*args, value)
-		*filterString = append(*filterString, fmt.Sprintf("%s=$%d", key, *index))
+		if tableAlias != "" {
+			*filterString = append(*filterString, fmt.Sprintf("%s.%s=$%d", tableAlias, key, *index))
+		} else {
+			*filterString = append(*filterString, fmt.Sprintf("%s=$%d", key, *index))
+		}
+
 		*index++
 	}
 

--- a/dsi/postgres/project_resources.go
+++ b/dsi/postgres/project_resources.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -337,7 +338,7 @@ func (d *Database) UpdateDefDocument(projectID, pathName, documentID string, upd
 	validFields := map[string]bool{"*": true}
 
 	// filters
-	filterErr := d.mapToQuery(translatedFilters, validFields, &filterString, &args, &index)
+	filterErr := d.mapToQuery(translatedFilters, validFields, &filterString, &args, &index, "")
 	if filterErr != nil {
 		return nil, dsiErrors.New(dsiErrors.UnknownError, filterErr)
 	}
@@ -370,7 +371,7 @@ func (d *Database) UpdateDefDocument(projectID, pathName, documentID string, upd
 }
 
 // ListDefDocuments retrieves all definition documents for the give project and path
-func (d *Database) ListDefDocuments(projectID, pathName string, limit, offset int64, filter map[string]interface{}, sort map[string]int) ([]map[string]interface{}, *dsiErrors.DatastoreError) {
+func (d *Database) ListDefDocuments(projectID, pathName string, limit, offset int64, filter map[string]interface{}, sort map[string]int, relations map[string]string) ([]map[string]interface{}, *dsiErrors.DatastoreError) {
 	// translate filters
 	translatedFilters := make(map[string]interface{})
 	for key, value := range filter {
@@ -396,19 +397,19 @@ func (d *Database) ListDefDocuments(projectID, pathName string, limit, offset in
 
 	// projectID
 	args = append(args, projectID)
-	filterString = append(filterString, fmt.Sprintf("project_id=$%d", index))
+	filterString = append(filterString, fmt.Sprintf("o.project_id=$%d", index))
 	index++
 
 	// path name
 	args = append(args, pathName)
-	filterString = append(filterString, fmt.Sprintf("resource_path=$%d", index))
+	filterString = append(filterString, fmt.Sprintf("o.resource_path=$%d", index))
 	index++
 
 	// valid sort/filter
 	validFields := map[string]bool{"*": true}
 
 	// filters
-	filterErr := d.mapToQuery(translatedFilters, validFields, &filterString, &args, &index)
+	filterErr := d.mapToQuery(translatedFilters, validFields, &filterString, &args, &index, "o")
 	if filterErr != nil {
 		return nil, dsiErrors.New(dsiErrors.UnknownError, filterErr)
 	}
@@ -456,15 +457,23 @@ func (d *Database) ListDefDocuments(projectID, pathName string, limit, offset in
 		index++
 	}
 
-	queryFields := "id, creator, creator_type, created, data"
+	queryFields := "o.id, o.creator, o.creator_type, o.created, o.data"
+	joins := ""
 	orderBy := ""
+
+	for k, r := range relations {
+		queryFields = fmt.Sprintf("%s || jsonb_build_object('%s', (%s.data || jsonb_build_object('id', %s.id)))", queryFields, r, r, r)
+		joins = fmt.Sprintf("%s LEFT JOIN project_resource_objects %s on (o.data->>'%s')::uuid = %s.id", joins, r, k, r)
+	}
+
 	if len(sortString) > 0 {
 		orderBy = fmt.Sprintf(" ORDER BY %s", strings.Join(sortString, ", "))
 	}
 	query := fmt.Sprintf(
-		"SELECT %s FROM %s WHERE %s%s%s",
+		"SELECT %s as data FROM %s o %s WHERE %s%s%s",
 		queryFields,
 		tableProjectResourceObjects,
+		joins,
 		strings.Join(filterString, " AND "),
 		orderBy,
 		pageString,
@@ -520,7 +529,7 @@ func (d *Database) ListDefDocuments(projectID, pathName string, limit, offset in
 }
 
 // GetDefDocument retrieves a single document
-func (d *Database) GetDefDocument(projectID, path, documentID string, filter map[string]interface{}) (map[string]interface{}, *dsiErrors.DatastoreError) {
+func (d *Database) GetDefDocument(projectID, path, documentID string, filter map[string]interface{}, relations map[string]string) (map[string]interface{}, *dsiErrors.DatastoreError) {
 	// translate filters
 	translatedFilters := make(map[string]interface{})
 	for key, value := range filter {
@@ -536,6 +545,7 @@ func (d *Database) GetDefDocument(projectID, path, documentID string, filter map
 		}
 	}
 
+	//GetDefinitionByPathName
 	args := make([]interface{}, 0)
 	index := 1
 
@@ -544,29 +554,39 @@ func (d *Database) GetDefDocument(projectID, path, documentID string, filter map
 
 	// projectID
 	args = append(args, projectID)
-	filterString = append(filterString, fmt.Sprintf("project_id=$%d", index))
+	filterString = append(filterString, fmt.Sprintf("o.project_id=$%d", index))
 	index++
 
 	// document id
 	args = append(args, documentID)
-	filterString = append(filterString, fmt.Sprintf("id=$%d", index))
+	filterString = append(filterString, fmt.Sprintf("o.id=$%d", index))
 	index++
 
 	// valid sort/filter
 	validFields := map[string]bool{"*": true}
 
 	// filters
-	filterErr := d.mapToQuery(translatedFilters, validFields, &filterString, &args, &index)
+	filterErr := d.mapToQuery(translatedFilters, validFields, &filterString, &args, &index, "o")
 	if filterErr != nil {
 		return nil, dsiErrors.New(dsiErrors.UnknownError, filterErr)
 	}
 
-	queryFields := "id, creator, creator_type, created, data"
+	queryFields := "o.id, o.creator, o.creator_type, o.created, o.data"
+	joins := ""
+
+	relationIndex := 0
+	for key, r := range relations {
+		alias := r + strconv.Itoa(relationIndex)
+		queryFields = fmt.Sprintf("%s - '%s' || jsonb_build_object('%s', (%s.data || jsonb_build_object('id', %s.id)))", queryFields, key, r, alias, alias)
+		joins = fmt.Sprintf("%s LEFT JOIN project_resource_objects %s on (o.data->>'%s')::uuid = %s.id", joins, alias, key, alias)
+		relationIndex++
+	}
 
 	query := fmt.Sprintf(
-		"SELECT %s FROM %s WHERE %s",
+		"SELECT %s as data FROM %s o %s WHERE %s",
 		queryFields,
 		tableProjectResourceObjects,
+		joins,
 		strings.Join(filterString, " AND "),
 	)
 
@@ -644,7 +664,7 @@ func (d *Database) CountDefDocuments(projectID, pathName string, filter map[stri
 	validFields := map[string]bool{"*": true}
 
 	// filters
-	filterErr := d.mapToQuery(translatedFilters, validFields, &filterString, &args, &index)
+	filterErr := d.mapToQuery(translatedFilters, validFields, &filterString, &args, &index, "")
 	if filterErr != nil {
 		return 0, dsiErrors.New(dsiErrors.UnknownError, filterErr)
 	}
@@ -706,7 +726,7 @@ func (d *Database) DeleteDefDocument(projectID, path, documentID string, filter 
 	validFields := map[string]bool{"*": true}
 
 	// filters
-	filterErr := d.mapToQuery(translatedFilters, validFields, &filterString, &args, &index)
+	filterErr := d.mapToQuery(translatedFilters, validFields, &filterString, &args, &index, "")
 	if filterErr != nil {
 		return dsiErrors.New(dsiErrors.UnknownError, filterErr)
 	}

--- a/projects/documents/handlers.go
+++ b/projects/documents/handlers.go
@@ -84,6 +84,7 @@ func (h *Documents) PutObject(c *gin.Context) {
 
 // ListObjects returns the list of objects for a resource
 func (h *Documents) ListObjects(c *gin.Context) {
+	queryRelations := c.QueryArray("_relation")
 	resourcePathName := c.Param("resourcePathName")
 	projectID := c.MustGet("projectId").(string)
 	authFilters := c.MustGet("filters").(map[string]interface{})
@@ -110,6 +111,7 @@ func (h *Documents) ListObjects(c *gin.Context) {
 	// Format query parameters
 	filter := make(map[string]interface{})
 	sort := make(map[string]int)
+	relations := make(map[string]string)
 
 	var resourceDefinition *models.ResourceDefinition
 	validSchema := &models.JSONSchemaObject{}
@@ -147,6 +149,15 @@ func (h *Documents) ListObjects(c *gin.Context) {
 			}
 		}
 
+		if k == dsi.RelationKey {
+			for key, value := range validSchema.Properties {
+				if val, ok := value["relation"]; ok && stringInSlice(val.(string), v) {
+					relations[key] = val.(string)
+				}
+			}
+			continue
+		}
+
 		_, ok := validSchema.Properties[k]
 		if !ok {
 			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("unable to filter on '%s'", k)})
@@ -176,7 +187,7 @@ func (h *Documents) ListObjects(c *gin.Context) {
 		return
 	}
 
-	documents, dsiErr := h.store.ListDefDocuments(projectID, resourcePathName, iLimit, iOffset, filter, sort)
+	documents, dsiErr := h.store.ListDefDocuments(projectID, resourcePathName, iLimit, iOffset, filter, sort, relations)
 
 	if dsiErr != nil {
 		c.JSON(dsiErr.Code(), gin.H{"error": dsiErr.Error()})
@@ -190,12 +201,41 @@ func (h *Documents) ListObjects(c *gin.Context) {
 
 // GetObject returns a single object with the resourceID for this resource
 func (h *Documents) GetObject(c *gin.Context) {
+	queryRelations := c.QueryArray("_relation")
 	resourcePathName := c.Param("resourcePathName")
 	resourceID := c.Param("resourceID")
 	projectID := c.MustGet("projectId").(string)
 	authFilters := c.MustGet("filters").(map[string]interface{})
 
-	document, err := h.store.GetDefDocument(projectID, resourcePathName, resourceID, authFilters)
+	relations := make(map[string]string)
+	var resourceDefinition *models.ResourceDefinition
+	validSchema := &models.JSONSchemaObject{}
+	for _, v := range queryRelations {
+		if resourceDefinition == nil || validSchema == nil {
+			// get resource definition if we do not already have it
+			resourceDefinition, err := h.store.GetDefinitionByPathName(projectID, resourcePathName)
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "could not retrieve resource definition to validate query parameters"})
+				return
+			}
+
+			// get property types
+			var pErr error
+			validSchema, pErr = resourceDefinition.GetSchema()
+			if pErr != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "error getting schema property types"})
+				return
+			}
+		}
+
+		for key, value := range validSchema.Properties {
+			if val, ok := value["relation"]; ok && val.(string) == v {
+				relations[key] = val.(string)
+			}
+		}
+	}
+
+	document, err := h.store.GetDefDocument(projectID, resourcePathName, resourceID, authFilters, relations)
 
 	if err != nil {
 		c.JSON(err.Code(), gin.H{"error": err.Error()})
@@ -220,4 +260,14 @@ func (h *Documents) DeleteObject(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusNoContent, gin.H{})
+}
+
+// probably need to move to a better place
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
 }

--- a/projects/documents/handlers.go
+++ b/projects/documents/handlers.go
@@ -84,7 +84,6 @@ func (h *Documents) PutObject(c *gin.Context) {
 
 // ListObjects returns the list of objects for a resource
 func (h *Documents) ListObjects(c *gin.Context) {
-	queryRelations := c.QueryArray("_relation")
 	resourcePathName := c.Param("resourcePathName")
 	projectID := c.MustGet("projectId").(string)
 	authFilters := c.MustGet("filters").(map[string]interface{})

--- a/projects/documents/handlers.go
+++ b/projects/documents/handlers.go
@@ -150,7 +150,7 @@ func (h *Documents) ListObjects(c *gin.Context) {
 
 		if k == dsi.RelationKey {
 			for key, value := range validSchema.Properties {
-				if val, ok := value["relation"]; ok && stringInSlice(val.(string), v) {
+				if val, ok := value["relation"]; ok && stringInSlice(key, v) {
 					relations[key] = val.(string)
 				}
 			}
@@ -228,7 +228,7 @@ func (h *Documents) GetObject(c *gin.Context) {
 		}
 
 		for key, value := range validSchema.Properties {
-			if val, ok := value["relation"]; ok && val.(string) == v {
+			if val, ok := value["relation"]; ok && key == v {
 				relations[key] = val.(string)
 			}
 		}


### PR DESCRIPTION
Add a way to retrieve data from relations

When a property is defined as a relation you can expand it passing a query param `_relation=NAME` 

Here is a small demo with a relation with album.

![Peek 2020-06-26 14-16](https://user-images.githubusercontent.com/200319/85856111-ac8c5e80-b7b7-11ea-857f-90ecad799f36.gif)

It works for both GET methods, multi and single

The gif is now wrong. to get the relation data you will have to specify the field name and not the relation path. This allows for multiple relations on the same resource path